### PR TITLE
db max_connectionsを減らす。複数インスタンスに対応するため

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 		panic(err.Error())
 	}
 	defer db.Close()
-	db.SetMaxOpenConns(66)
+	db.SetMaxOpenConns(5)
 
 	resc := make(chan EventLog, 200000)
 


### PR DESCRIPTION
https://github.com/voyagegroup/hakaru201911-team-c/issues/33
このissueの一環。
1インスタンスのdb max connectionsを66にしているとインスタンスを増やした時にRDSのmax connectionsを超えてしまう。

なので減らす