### PR TITLE
update chunk size

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func insertChunk(valueStrings []string, valueArgs [](interface{}), db *sql.DB) {
 }
 
 func insert(resc chan EventLog, db *sql.DB) {
-	const chunkSize = 1000
+	const chunkSize = 20000
 
 	valueStrings := []string{}
 	valueArgs := [](interface{}){}


### PR DESCRIPTION
mysqlのPrepared statementのプレスホルダーの上限個数は65,535である。

event logは3カラムなので20,000件インサートすれば、プレスホルダー数は60,000になるのではないか。

なのでchunk sizeを20,000に変更する。

## このPRの背景
close: https://github.com/voyagegroup/hakaru201911-team-c/issues/35